### PR TITLE
docs: Add development script instructions to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@
 
 AINative Studio is a powerful, open-source AI-Native development environment with built-in AI capabilities, forked from Void Editor and VS Code.
 
+## 🛠️ Development Scripts
+
+For developers working on AINative Studio, use these convenient scripts in the `ainative-studio/` directory:
+
+```bash
+cd ainative-studio
+
+# Full development setup (first time or when dependencies change)
+./dev-start.sh      # Installs dependencies, builds, and runs with watch mode
+
+# Quick start (when already built)
+./dev-quick.sh      # Just starts the application (faster)
+
+# Stop all development processes
+./dev-stop.sh       # Stops watch processes and application
+```
+
 ## ✨ Features
 
 - AI-powered code completion and generation

--- a/ainative-studio/README.md
+++ b/ainative-studio/README.md
@@ -15,6 +15,26 @@ Use AI agents on your codebase, checkpoint and visualize changes, and bring any 
 
 This repo contains the full sourcecode for AINative Studio. If you're new, welcome!
 
+## 🚀 Quick Development Setup
+
+Use these convenient development scripts for easy setup and management:
+
+```bash
+# Full development setup (first time or when dependencies change)
+./dev-start.sh      # Installs dependencies, builds, and runs with watch mode
+
+# Quick start (when already built)
+./dev-quick.sh      # Just starts the application (faster)
+
+# Stop all development processes
+./dev-stop.sh       # Stops watch processes and application
+```
+
+**What each script does:**
+- `dev-start.sh`: Complete setup including dependency installation, React component building, TypeScript compilation with watch mode, and application launch
+- `dev-quick.sh`: Quick application start (assumes project is already built)
+- `dev-stop.sh`: Cleanly stops all development processes (watch builds and application)
+
 - 🧭 [Website](https://voideditor.com)
 
 - 👋 [Discord](https://discord.gg/RSNjgaugJs)


### PR DESCRIPTION
Add convenient development script usage instructions to both README.md files:
- Main README: Added Development Scripts section with basic usage
- ainative-studio README: Added Quick Development Setup with detailed explanations

These scripts (dev-start.sh, dev-quick.sh, dev-stop.sh) provide streamlined development workflow for contributors.

🤖 Generated with [Claude Code](https://claude.ai/code)