### PR TITLE
ci: install libkrb5-dev for Linux build

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -23,6 +23,10 @@ jobs:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: 'ainative-studio/package-lock.json'
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libkrb5-dev
       - name: Install build dependencies
         working-directory: ainative-studio/build
         run: |


### PR DESCRIPTION
## Summary
- install libkrb5-dev system dependency for Linux build workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e48e6b1c832c8fe065345dc12ece