### PR TITLE
ci: build macOS minified client before packaging

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -57,11 +57,16 @@ jobs:
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build
+      - name: Build and minify client
         working-directory: ainative-studio
         run: |
           npm run buildreact
-          npm run gulp vscode-darwin-${{ matrix.arch }}-min-ci
+          npm run gulp vscode-darwin-${{ matrix.arch }}-min
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Package
+        working-directory: ainative-studio
+        run: npm run gulp vscode-darwin-${{ matrix.arch }}-min-ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify build output


### PR DESCRIPTION
## Summary
- build and minify macOS client before invoking `vscode-darwin-*-min-ci`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e559e500832cb61ccb67a2e9f229