### PR TITLE
Fix Windows build path for CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -60,14 +60,14 @@ jobs:
             Write-Error "Build output directory not found!"
             exit 1
           }
-        working-directory: ainative-studio
+        working-directory: .
       - name: Create archive
-        working-directory: ainative-studio/VSCode-win32-x64
-        run: 7z a -tzip ../../ainative-studio-win32-x64.zip .
+        working-directory: VSCode-win32-x64
+        run: 7z a -tzip ../ainative-studio-win32-x64.zip .
         shell: cmd
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ainative-studio-win32-x64
-          path: ainative-studio/ainative-studio-win32-x64.zip
+          path: ainative-studio-win32-x64.zip
           retention-days: 7


### PR DESCRIPTION
## Summary
- fix Windows CI build path to check for artifacts at repo root
- archive and upload Windows build output from the correct location

## Testing
- `npm test`
- `npm ci` *(fails: Package 'xkbfile' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f0ba8c3c832c887857b4220f8d91