### PR TITLE
Fix Windows workflow artifact paths

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,20 +54,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify build output
+        working-directory: ainative-studio
         shell: pwsh
         run: |
           if (-not (Test-Path VSCode-win32-x64)) {
             Write-Error "Build output directory not found!"
             exit 1
           }
-        working-directory: .
       - name: Create archive
-        working-directory: VSCode-win32-x64
+        working-directory: ainative-studio/VSCode-win32-x64
         run: 7z a -tzip ../ainative-studio-win32-x64.zip .
         shell: cmd
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ainative-studio-win32-x64
-          path: ainative-studio-win32-x64.zip
+          path: ainative-studio/ainative-studio-win32-x64.zip
           retention-days: 7


### PR DESCRIPTION
## Summary
- fix Verify build output step to run in `ainative-studio`
- archive build output from inside `ainative-studio/VSCode-win32-x64`
- upload Windows build artifact from new location

## Testing
- `git commit -am "fix windows build artifact path"` *(fails: Cannot find module 'gulp-filter')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f5bc048c832c80d5f2790db2099b