### PR TITLE
chore: cache build dependencies

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,7 +22,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: 'ainative-studio/package-lock.json'
+          cache-dependency-path: |
+            ainative-studio/package-lock.json
+            ainative-studio/build/package-lock.json
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: 'ainative-studio/package-lock.json'
+          cache-dependency-path: |
+            ainative-studio/package-lock.json
+            ainative-studio/build/package-lock.json
       - name: Install build dependencies
         working-directory: ainative-studio/build
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -22,7 +22,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: 'ainative-studio/package-lock.json'
+          cache-dependency-path: |
+            ainative-studio/package-lock.json
+            ainative-studio/build/package-lock.json
       - name: Install build dependencies
         working-directory: ainative-studio/build
         run: |


### PR DESCRIPTION
## Summary
- cache build and workspace lock files in CI workflows to speed up installs

## Testing
- `npm test`
- `npm ci` *(fails: missing gssapi/gssapi.h while building kerberos)*

------
https://chatgpt.com/codex/tasks/task_e_68a10131140c832cb3f7c468fc82dfda