### PR TITLE
chore: compile before linux min build

### DIFF
--- a/ainative-studio/build/azure-pipelines/linux/product-build-linux.yml
+++ b/ainative-studio/build/azure-pipelines/linux/product-build-linux.yml
@@ -197,6 +197,7 @@ steps:
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     - script: |
         set -e
+        npm run gulp compile
         npm run gulp vscode-linux-$(VSCODE_ARCH)-min-ci
         ARCHIVE_PATH=".build/linux/client/code-${{ parameters.VSCODE_QUALITY }}-$(VSCODE_ARCH)-$(date +%s).tar.gz"
         mkdir -p $(dirname $ARCHIVE_PATH)


### PR DESCRIPTION
## Summary
- ensure Linux product build compiles sources before running the minified build step

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fb079798832cbbe59f195e3f367d